### PR TITLE
FancyDatePicker with Input

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "firebase": "^3.7.5",
     "moment": "^2.18.1",
     "react": "^15.4.2",
+    "react-day-picker": "^5.5.3",
     "react-dom": "^15.4.2",
     "react-redux": "^5.0.4",
     "redux": "^3.6.0"

--- a/src/components/brew-input.js
+++ b/src/components/brew-input.js
@@ -4,7 +4,9 @@ import moment from 'moment';
 
 import {addBrew} from '../database/brew';
 import {FancyInput, FancyDropdown, FancyButton} from './input-stuff.js';
-import FancyDatePicker from './date-picker.js';
+import DayPickerInput from "react-day-picker/DayPickerInput";
+
+import "react-day-picker/lib/style.css"
 
 
 var testEquip = ["Chemex", "Clever", "French Press"];
@@ -19,10 +21,18 @@ const FirstPanel = (props) => {
         />
       <FancyInput label="Brew Date" name="brewDate" handleChange={props.handleChange}
         value={props.brewDate} />
-      <FancyDatePicker />
+      <DayPickerInput
+          name="brewDate"
+          label="Brew Date"
+          placeholder={props.brewDate}
+          format="DD/MM/YYYY"
+          onDayChange={props.handleDayChange}
+          dayPickerProps={{
+            enableOutsideDays: true,
+          }}
+        />
       <FancyButton name="dateButton"
         onClick={props.setDateToday}
-        //handleSubmit={()=>console.log("date")}
         buttonText="Set Date to Today"/>
     </div>
   )
@@ -52,6 +62,7 @@ const ThirdPanel = (props) => {
  )
 }
 
+
 class FancyCarouselForm extends React.Component {
   constructor (props){
     super(props);
@@ -59,6 +70,8 @@ class FancyCarouselForm extends React.Component {
   }
 
   handleChange = (evt) => this.setState({[evt.target.name]: evt.target.value});
+
+  handleDayChange = day => this.setState({brewDate: moment(day).format("M/D/Y")});
 
   setDateToday = (event) => {
     const today = new Date();
@@ -103,7 +116,8 @@ render() {
 
   return <div className="brew-input">
     { this.state.page === 1 && <FirstPanel handleChange={this.handleChange}
-      name={this.state.name} brewDate={this.state.brewDate} setDateToday={this.setDateToday} />}
+      name={this.state.name} brewDate={this.state.brewDate} setDateToday={this.setDateToday}
+      handleDayChange={this.handleDayChange} />}
     { this.state.page === 2 && <SecondPanel handleChange={this.handleChange}
       brewTime={this.state.time} amount={this.state.amount}
       grindSetting={this.state.grindSetting} />}

--- a/src/components/brew-input.js
+++ b/src/components/brew-input.js
@@ -3,7 +3,8 @@ import {connect} from 'react-redux';
 import moment from 'moment';
 
 import {addBrew} from '../database/brew';
-import {FancyInput, FancyDropdown, FancyButton, FancyDatePicker} from './input-stuff.js'
+import {FancyInput, FancyDropdown, FancyButton} from './input-stuff.js';
+import FancyDatePicker from './date-picker.js';
 
 
 var testEquip = ["Chemex", "Clever", "French Press"];

--- a/src/components/brew-input.js
+++ b/src/components/brew-input.js
@@ -3,10 +3,7 @@ import {connect} from 'react-redux';
 import moment from 'moment';
 
 import {addBrew} from '../database/brew';
-import {FancyInput, FancyDropdown, FancyButton} from './input-stuff.js';
-import DayPickerInput from "react-day-picker/DayPickerInput";
-
-import "react-day-picker/lib/style.css"
+import {FancyInput, FancyDropdown, FancyButton, FancyDayPickerInput} from './input-stuff.js';
 
 
 var testEquip = ["Chemex", "Clever", "French Press"];
@@ -19,27 +16,18 @@ const FirstPanel = (props) => {
       <FancyDropdown label="Brew Method " name="brewMethod" handleChange={props.handleChange}
         options={testEquip}
         />
-      <FancyInput label="Brew Date" name="brewDate" handleChange={props.handleChange}
-        value={props.brewDate} />
-      <DayPickerInput
-          name="brewDate"
+      <FancyDayPickerInput
           label="Brew Date"
+          name="brewDate"
           placeholder={props.brewDate}
-          format="DD/MM/YYYY"
           onDayChange={props.handleDayChange}
-          dayPickerProps={{
-            enableOutsideDays: true,
-          }}
         />
-      <FancyButton name="dateButton"
-        onClick={props.setDateToday}
-        buttonText="Set Date to Today"/>
+      <FancyButton name="dateButton" onClick={props.setDateToday} buttonText="Set Date to Today"/>
     </div>
   )
 }
 
 const SecondPanel = (props) => {
-
   return (
     <div>
       <FancyInput label="Brew Time " name="time" handleChange={props.handleChange}
@@ -73,9 +61,10 @@ class FancyCarouselForm extends React.Component {
 
   handleDayChange = day => this.setState({brewDate: moment(day).format("M/D/Y")});
 
-  setDateToday = (event) => {
+  setDateToday = () => {
     const today = new Date();
-    this.setState({["brewDate"]: moment(today).format("M/D/Y")});
+    // this.setState({brewDate: moment(today).format("M/D/Y")});
+    this.handleDayChange(today);
   };
 
   handleSubmit = (event) => {

--- a/src/components/brew-input.js
+++ b/src/components/brew-input.js
@@ -3,7 +3,7 @@ import {connect} from 'react-redux';
 import moment from 'moment';
 
 import {addBrew} from '../database/brew';
-import {FancyInput, FancyDropdown, FancyButton} from './input-stuff.js'
+import {FancyInput, FancyDropdown, FancyButton, FancyDatePicker} from './input-stuff.js'
 
 
 var testEquip = ["Chemex", "Clever", "French Press"];
@@ -18,8 +18,9 @@ const FirstPanel = (props) => {
         />
       <FancyInput label="Brew Date" name="brewDate" handleChange={props.handleChange}
         value={props.brewDate} />
+      <FancyDatePicker />
       <FancyButton name="dateButton"
-        handleSubmit={props.setDateToday}
+        onClick={props.setDateToday}
         //handleSubmit={()=>console.log("date")}
         buttonText="Set Date to Today"/>
     </div>

--- a/src/components/date-picker.js
+++ b/src/components/date-picker.js
@@ -1,32 +1,7 @@
 import React from 'react';
-import DayPickerInput from "react-day-picker/DayPickerInput";
-
-import "react-day-picker/lib/style.css"
 
 
 
-class FancyDatePicker extends React.Component {
-  handleDayChange = day => {
-    this.setState({
-      brewDate: day
-    })
-  }
 
-  render() {
-    return (
-      <form>
-        <DayPickerInput
-          name="brewDate"
-          placeholder="DD/MM/YYYY"
-          format="DD/MM/YYYY"
-          onDayChange={ this.handleDayChange }
-          dayPickerProps={{
-            enableOutsideDays: true,
-          }}
-        />
-      </form>
-    )
-  }
-}
 
 export default FancyDatePicker;

--- a/src/components/date-picker.js
+++ b/src/components/date-picker.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import DayPickerInput from "react-day-picker/DayPickerInput";
+
+import "react-day-picker/lib/style.css"
+
+
+
+class FancyDatePicker extends React.Component {
+  handleDayChange = day => {
+    this.setState({
+      brewDate: day
+    })
+  }
+
+  render() {
+    return (
+      <form>
+        <DayPickerInput
+          name="brewDate"
+          placeholder="DD/MM/YYYY"
+          format="DD/MM/YYYY"
+          onDayChange={ this.handleDayChange }
+          dayPickerProps={{
+            enableOutsideDays: true,
+          }}
+        />
+      </form>
+    )
+  }
+}
+
+export default FancyDatePicker;

--- a/src/components/input-stuff.js
+++ b/src/components/input-stuff.js
@@ -1,7 +1,5 @@
 import React from 'react';
-import DayPickerInput from "react-day-picker/DayPickerInput";
 
-import "react-day-picker/lib/style.css"
 
 const FancyInput = (props) => {
   return (
@@ -30,29 +28,6 @@ const FancyButton = (props) => {
     )
 }
 
-class FancyDatePicker extends React.Component {
-  handleBirthdayChange = day => {
-    this.setState({
-      birthday: day
-    })
-  }
-
-  render() {
-    return (
-      <form>
-        <DayPickerInput
-          name="birthday"
-          placeholder="DD/MM/YYYY"
-          format="DD/MM/YYYY"
-          onDayChange={ this.handleBirthdayChange }
-          dayPickerProps={{
-            enableOutsideDays: true,
-          }}
-        />
-      </form>
-    )
-  }
-}
 
 
-export {FancyInput, FancyDropdown, FancyButton, FancyDatePicker};
+export {FancyInput, FancyDropdown, FancyButton};

--- a/src/components/input-stuff.js
+++ b/src/components/input-stuff.js
@@ -14,7 +14,7 @@ const FancyDropdown = (props) => {
     <div>
       <label className="input-label"> {props.label}
       <select name={props.name} onChange={props.handleChange}>
-        {props.options.map(equip => <option value={equip}>{equip}</option>)}
+        {props.options.map(equip => <option key={equip} value={equip}>{equip}</option>)}
       </select>
       </label>
     </div>)

--- a/src/components/input-stuff.js
+++ b/src/components/input-stuff.js
@@ -1,5 +1,7 @@
 import React from 'react';
+import DayPickerInput from "react-day-picker/DayPickerInput";
 
+import "react-day-picker/lib/style.css"
 
 const FancyInput = (props) => {
   return (
@@ -28,4 +30,29 @@ const FancyButton = (props) => {
     )
 }
 
-export {FancyInput, FancyDropdown, FancyButton};
+class FancyDatePicker extends React.Component {
+  handleBirthdayChange = day => {
+    this.setState({
+      birthday: day
+    })
+  }
+
+  render() {
+    return (
+      <form>
+        <DayPickerInput
+          name="birthday"
+          placeholder="DD/MM/YYYY"
+          format="DD/MM/YYYY"
+          onDayChange={ this.handleBirthdayChange }
+          dayPickerProps={{
+            enableOutsideDays: true,
+          }}
+        />
+      </form>
+    )
+  }
+}
+
+
+export {FancyInput, FancyDropdown, FancyButton, FancyDatePicker};

--- a/src/components/input-stuff.js
+++ b/src/components/input-stuff.js
@@ -1,4 +1,7 @@
 import React from 'react';
+import DayPickerInput from "react-day-picker/DayPickerInput";
+
+import "react-day-picker/lib/style.css"
 
 
 const FancyInput = (props) => {
@@ -28,6 +31,23 @@ const FancyButton = (props) => {
     )
 }
 
+const FancyDayPickerInput = (props) => {
+  return(
+    <label className="input-label"> {props.label}
+      <DayPickerInput
+          name={props.name}
+          placeholder={props.brewDate}
+          format="DD/MM/YYYY"
+          onDayChange={props.handleDayChange}
+          dayPickerProps={{
+            enableOutsideDays: true,
+          }}
+        />
+      </label>
+      )
+    }
 
 
-export {FancyInput, FancyDropdown, FancyButton};
+
+
+export {FancyInput, FancyDropdown, FancyButton, FancyDayPickerInput};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4050,7 +4050,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -4948,6 +4948,13 @@ prop-types@^15.0.0, prop-types@^15.5.2, prop-types@~15.5.0:
   dependencies:
     fbjs "^0.8.9"
 
+prop-types@^15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+
 proxy-addr@~1.1.3:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.4.tgz#27e545f6960a44a627d9b44467e35c1b6b4ce2f3"
@@ -5017,6 +5024,12 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-day-picker@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-5.5.3.tgz#d6a03bb0b15c6bb58629d749d8a7489cf6cfa52b"
+  dependencies:
+    prop-types "^15.5.10"
 
 react-dev-utils@^0.5.2:
   version "0.5.2"


### PR DESCRIPTION
I’ve added the React-Day-Picker input form to have the calendar appear to pick a day. Currently all days are options to be picked, but that can be changed. 

http://react-day-picker.js.org/Input.html

I don’t understand why my “set to today” button isn’t working. 